### PR TITLE
build from pip rather than copy source

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -2,7 +2,7 @@
 name: Docker Image
 on:
   push:
-    branches: [main]
+    branches: [main, build*]
     tags: [v*]
 jobs:
   build-push-docker:
@@ -10,9 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Get pymodbus
-        run: |
-          ./get-pymodbus.sh
       - name: Login to the Container Registry
         uses: docker/login-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,11 @@
 
 FROM python:3.9-slim-buster
 
-WORKDIR /pymodbus
+WORKDIR /
 
 EXPOSE 8080
 EXPOSE 5020
 
-COPY pymodbus .
+RUN pip3 install --no-cache-dir pymodbus[repl]==3.1.0
 
-RUN pip3 install --no-cache-dir -r requirements.txt && pip3 install --no-cache-dir -e .
-
-CMD [ "pymodbus.server", "--host", "0.0.0.0", "--web-port", "8080", "verbose", "--no-repl", "run", "--modbus-port", "5020", "--modbus-server", "tcp" ]
+CMD [ "pymodbus.server", "--host", "0.0.0.0", "--web-port", "8080", "--verbose", "--no-repl", "run", "--modbus-port", "5020", "--modbus-server", "tcp" ]

--- a/get-pymodbus.sh
+++ b/get-pymodbus.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-git clone -b v3.1.0 https://github.com/pymodbus-dev/pymodbus


### PR DESCRIPTION
Installing the `repl` set of requirements enables `pymodbus.server` to run and means we can avoid pulling source code.